### PR TITLE
Drop ca mgm

### DIFF
--- a/package/yast2-auth-server.spec
+++ b/package/yast2-auth-server.spec
@@ -28,7 +28,7 @@ License:        GPL-2.0+ and MIT
 BuildRequires:	boost-devel gcc-c++ libldapcpp-devel libtool perl-Digest-SHA1 perl-gettext perl-X500-DN pkg-config update-desktop-files yast2 yast2-core-devel yast2-ldap yast2-users
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  cyrus-sasl-devel
-Requires:	acl net-tools perl perl-Digest-SHA1 perl-gettext perl-X500-DN yast2 yast2-ca-management yast2-perl-bindings
+Requires:	acl net-tools perl perl-Digest-SHA1 perl-gettext perl-X500-DN yast2 yast2-perl-bindings
 
 # users/ldap_dialogs.ycp
 Requires:       yast2-users >= 2.22.3

--- a/src/clients/auth-server_proposal.rb
+++ b/src/clients/auth-server_proposal.rb
@@ -339,17 +339,6 @@ module Yast
           Ops.set(@ldapclient_defaults, "file_server", true)
           Ops.set(@ldapclient_defaults, "create_ldap", true)
 
-          if !AuthServer.HaveCommonServerCertificate
-            Report.Error(
-              _(
-                "OpenLDAP Server: Common server certificate not available.\nStartTLS is disabled."
-              )
-            )
-          else
-            Ops.set(@ldapclient_defaults, "ldap_tls", true)
-            AuthServer.WriteTlsConfigCommonCert
-          end
-
           Ldap.SetDefaults(@ldapclient_defaults)
           Ldap.SetBindPassword(Ops.get_string(@defaults, "rootpw_clear", ""))
           AuthServer.WriteSLPEnabled(

--- a/src/desktop/auth-server.desktop
+++ b/src/desktop/auth-server.desktop
@@ -14,7 +14,7 @@ X-SuSE-YaST-Geometry=
 X-SuSE-YaST-SortKey=
 X-SuSE-YaST-AutoInstResource=auth-server
 X-SuSE-YaST-AutoInstClonable=true
-X-SuSE-YaST-AutoInstRequires=lan,ca_mgm
+X-SuSE-YaST-AutoInstRequires=lan
 X-SuSE-YaST-AutoInstSchema=auth-server.rnc
 
 Icon=yast-ldap-server

--- a/src/include/auth-server/tree_structure.rb
+++ b/src/include/auth-server/tree_structure.rb
@@ -392,20 +392,9 @@ module Yast
         UI.ChangeWidget(:cb_tls_enabled, :Value, true)
         UI.ChangeWidget(:cb_ssl_listener_enabled, :Enabled, true)
 
-        if Ops.get_string(tls, "caCertFile", "") == "/etc/pki/trust/anchors/YaST-CA.pem" &&
-            Ops.get_string(tls, "certFile", "") ==
-              "/etc/ssl/servercerts/servercert.pem" &&
-            Ops.get_string(tls, "certKeyFile", "") ==
-              "/etc/ssl/servercerts/serverkey.pem"
-          UI.ChangeWidget(:cb_use_common_cert, :Value, true)
-          UI.ChangeWidget(:fr_import_cert, :Enabled, false)
-        else
-          UI.ChangeWidget(:cb_use_common_cert, :Value, false)
-          UI.ChangeWidget(:fr_import_cert, :Enabled, true)
-        end
+        UI.ChangeWidget(:fr_import_cert, :Enabled, true)
       else
         UI.ChangeWidget(:cb_ssl_listener_enabled, :Enabled, false)
-        UI.ChangeWidget(:cb_use_common_cert, :Enabled, false)
         UI.ChangeWidget(:fr_import_cert, :Enabled, false)
       end
       UI.ChangeWidget(
@@ -501,8 +490,6 @@ module Yast
     def cb_input_tls
       Builtins.y2milestone("calling tls input handler")
 
-      common_cert_available = AuthServer.HaveCommonServerCertificate
-
       if @handler_cmd == :cb_tls_enabled
         tls_enabled_cb = Convert.to_boolean(
           UI.QueryWidget(:cb_tls_enabled, :Value)
@@ -510,54 +497,10 @@ module Yast
         if tls_enabled_cb
           UI.ChangeWidget(:cb_ssl_listener_enabled, :Enabled, true)
           UI.ChangeWidget(:cb_ssl_listener_enabled, :Value, true)
-          if common_cert_available
-            UI.ChangeWidget(:cb_use_common_cert, :Enabled, true)
-            UI.ChangeWidget(:cb_use_common_cert, :Value, true)
-            UI.ChangeWidget(:te_ca_file, :Value, "/etc/pki/trust/anchors/YaST-CA.pem")
-            UI.ChangeWidget(
-              :te_cert_file,
-              :Value,
-              "/etc/ssl/servercerts/servercert.pem"
-            )
-            UI.ChangeWidget(
-              :te_key_file,
-              :Value,
-              "/etc/ssl/servercerts/serverkey.pem"
-            )
-            UI.ChangeWidget(:fr_import_cert, :Enabled, false)
-          else
-            UI.ChangeWidget(:fr_import_cert, :Enabled, true)
-          end
+          UI.ChangeWidget(:fr_import_cert, :Enabled, true)
         else
           UI.ChangeWidget(:cb_ssl_listener_enabled, :Enabled, false)
-          UI.ChangeWidget(:cb_use_common_cert, :Enabled, false)
           UI.ChangeWidget(:fr_import_cert, :Enabled, false)
-        end
-      elsif @handler_cmd == :cb_use_common_cert
-        use_common_cert = Convert.to_boolean(
-          UI.QueryWidget(:cb_use_common_cert, :Value)
-        )
-        if use_common_cert
-          if common_cert_available
-            UI.ChangeWidget(:te_ca_file, :Value, "/etc/pki/trust/anchors/YaST-CA.pem")
-            UI.ChangeWidget(
-              :te_cert_file,
-              :Value,
-              "/etc/ssl/servercerts/servercert.pem"
-            )
-            UI.ChangeWidget(
-              :te_key_file,
-              :Value,
-              "/etc/ssl/servercerts/serverkey.pem"
-            )
-            UI.ChangeWidget(:fr_import_cert, :Enabled, false)
-          else
-            Popup.Error(_("A common server certificate is not available."))
-            UI.ChangeWidget(:cb_use_common_cert, :Value, false)
-            UI.ChangeWidget(:cb_use_common_cert, :Enabled, false)
-          end
-        else
-          UI.ChangeWidget(:fr_import_cert, :Enabled, true)
         end
       elsif @handler_cmd == :pb_ca_file
         # file selection headline
@@ -583,9 +526,6 @@ module Yast
           _("Select Certificate Key File")
         )
         UI.ChangeWidget(:te_key_file, :Value, name) if name != nil
-      elsif @handler_cmd == :pb_launch_ca
-        WFM.CallFunction("ca_mgm", [])
-        cb_read_tls
       end
       #reread tls page
       true

--- a/src/include/auth-server/widgets.rb
+++ b/src/include/auth-server/widgets.rb
@@ -235,14 +235,6 @@ module Yast
                     false
                   )
                 ),
-                Left(
-                  CheckBox(
-                    Id(:cb_use_common_cert),
-                    Opt(:notify),
-                    _("Use common Server Certificate"),
-                    false
-                  )
-                ),
                 HStretch()
               )
             )


### PR DESCRIPTION
yast2 ca-mangement module is broken and will not be fixed. It should get dropped.
This commit removes it from yast2-auth-server
