### PR TITLE
Fixed an untranslated string (bsc#988393)

### DIFF
--- a/src/include/auth-server/dialogs.rb
+++ b/src/include/auth-server/dialogs.rb
@@ -1147,7 +1147,7 @@ module Yast
                 ""
               ),
               HSpacing(),
-              HSquash(IntField(Id(:if_sync_port), "Port", 0, 65536, 389)),
+              HSquash(IntField(Id(:if_sync_port), _("Port"), 0, 65536, 389)),
               HSpacing(),
               VBox(
                 Bottom(CheckBox(Id(:cb_start_tls), _("Use StartTLS"), true)),


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=988393

the string is present in the textdomain already, no update of POT file is needed