### PR TITLE
Fixes to make the YaST modules work

### DIFF
--- a/src/lib/authserver/dir/ds389.rb
+++ b/src/lib/authserver/dir/ds389.rb
@@ -90,6 +90,12 @@ AddSampleEntries=No
     return result.value.exitstatus == 0
   end
 
+  # enable the directory service specified by the instance name. Returns true only on success.
+  def self.enable(instance_name)
+    _, _, result = Open3.popen2e('/usr/bin/systemctl', 'enable', 'dirsrv@' + instance_name)
+    return result.value.exitstatus == 0
+  end
+
   # install_tls_in_nss copies the specified CA and pkcs12 certificate+key into NSS database of 389 instance.
   def self.install_tls_in_nss(instance_name, ca_path, p12_path, pk_pass)
     instance_dir = '/etc/dirsrv/slapd-' + instance_name

--- a/src/lib/authserver/dir/ds389.rb
+++ b/src/lib/authserver/dir/ds389.rb
@@ -92,7 +92,17 @@ AddSampleEntries=No
 
   # enable the directory service specified by the instance name. Returns true only on success.
   def self.enable(instance_name)
-    _, _, result = Open3.popen2e('/usr/bin/systemctl', 'enable', 'dirsrv@' + instance_name)
+    _, stdouterr, result = Open3.popen2e('/usr/bin/mkdir', '-p', '/etc/systemd/system/dirsrv.target.wants')
+    append_to_log(stdouterr.readlines.join('\n'))
+    if result.value.exitstatus != 0
+	return false
+    end
+    _, stdouterr, result = Open3.popen2e('/usr/bin/ln', '-sf', '/usr/lib/systemd/system/dirsrv@.service', '/etc/systemd/system/dirsrv.target.wants/dirsrv@' + instance_name + '.service')
+    append_to_log(stdouterr.readlines.join('\n'))
+    if result.value.exitstatus != 0
+        return false
+    end
+    _, _, result = Open3.popen2e('/usr/bin/systemctl', 'enable', 'dirsrv.target')
     return result.value.exitstatus == 0
   end
 

--- a/src/lib/authserver/dir/ds389.rb
+++ b/src/lib/authserver/dir/ds389.rb
@@ -92,15 +92,9 @@ AddSampleEntries=No
 
   # enable the directory service specified by the instance name. Returns true only on success.
   def self.enable(instance_name)
-    _, stdouterr, result = Open3.popen2e('/usr/bin/mkdir', '-p', '/etc/systemd/system/dirsrv.target.wants')
-    append_to_log(stdouterr.readlines.join('\n'))
+    _, _, result = Open3.popen2e('/usr/bin/systemctl', 'enable', '/etc/systemd/system/dirsrv.target.wants/dirsrv@' + instance_name + '.service')
     if result.value.exitstatus != 0
 	return false
-    end
-    _, stdouterr, result = Open3.popen2e('/usr/bin/ln', '-sf', '/usr/lib/systemd/system/dirsrv@.service', '/etc/systemd/system/dirsrv.target.wants/dirsrv@' + instance_name + '.service')
-    append_to_log(stdouterr.readlines.join('\n'))
-    if result.value.exitstatus != 0
-        return false
     end
     _, _, result = Open3.popen2e('/usr/bin/systemctl', 'enable', 'dirsrv.target')
     return result.value.exitstatus == 0

--- a/src/lib/authserver/krb/mit.rb
+++ b/src/lib/authserver/krb/mit.rb
@@ -110,7 +110,7 @@ class MITKerberos
   # init_dir uses kerberos LDAP utility to prepare a directory server for kerberos operation.
   # Returns tuple of command output and boolean (success or not).
   def self.init_dir(ldaps_addr, dir_admin_dn, dir_admin_pass, realm_name, container_dn, master_pass)
-    puts ['/usr/lib/mit/sbin/kdb5_ldap_util', '-H', 'ldaps://'+ldaps_addr, '-D', dir_admin_dn, '-w', dir_admin_pass, 'create', '-r', realm_name, '-subtrees', container_dn, '-s', '-P', master_pass].join(' ')
+    #puts ['/usr/lib/mit/sbin/kdb5_ldap_util', '-H', 'ldaps://'+ldaps_addr, '-D', dir_admin_dn, '-w', dir_admin_pass, 'create', '-r', realm_name, '-subtrees', container_dn, '-s', '-P', master_pass].join(' ')
     stdin, stdouterr, result = Open3.popen2e('/usr/lib/mit/sbin/kdb5_ldap_util', '-H', 'ldaps://'+ldaps_addr, '-D', dir_admin_dn, '-w', dir_admin_pass, 'create', '-r', realm_name, '-subtrees', container_dn, '-s', '-P', master_pass)
     stdin.close
     return [stdouterr.readlines.join('\n'), result.value.exitstatus == 0]

--- a/src/lib/authserver/krb/mit.rb
+++ b/src/lib/authserver/krb/mit.rb
@@ -24,7 +24,7 @@ class MITKerberos
   def self.install_pkgs
     Yast.import 'Package'
     # DoInstall never fails
-    Package.DoInstall(['krb5-client', 'krb5-server'].delete_if{|name| Package.Installed(name)})
+    Package.DoInstall(['krb5-client', 'krb5-server', 'krb5-plugin-kdb-ldap'].delete_if{|name| Package.Installed(name)})
   end
 
   # is_configured returns true only if there kerberos configuration has been altered.
@@ -125,6 +125,18 @@ class MITKerberos
   # restart_kadmind restarts kerberos administration service. Returns true only on success.
   def self.restart_kadmind
     _, _, result = Open3.popen2e('/usr/bin/systemctl', 'restart', 'kadmind')
+    return result.value.exitstatus == 0
+  end
+
+  # enable KDC system service. Returns true only on success.
+  def self.enable_kdc
+    _, _, result = Open3.popen2e('/usr/bin/systemctl', 'enable', 'krb5kdc')
+    return result.value.exitstatus == 0
+  end
+
+  # enable kerberos administration service. Returns true only on success.
+  def self.enable_kadmind
+    _, _, result = Open3.popen2e('/usr/bin/systemctl', 'enable', 'kadmind')
     return result.value.exitstatus == 0
   end
 

--- a/src/lib/authserver/ui/new_dir_inst.rb
+++ b/src/lib/authserver/ui/new_dir_inst.rb
@@ -141,7 +141,7 @@ class NewDirInst < UI::Dialog
         fh.puts(DS389.gen_ldap_conf(fqdn, suffix))
       }
       if !DS389.enable(instance_name)
-        Popup.Error(_('Failed to enable directory instance, please inspect the journal of dirsrv@%s.service') % [instance_name])
+        Popup.Error(_('Failed to enable directory instance, please inspect the journal of dirsrv@%s.service and dirsrv.target. Log output may be found in %s') % [instance_name] % [DS_SETUP_LOG_PATH])
         raise
       end
       UI.ReplaceWidget(Id(:busy), Empty())

--- a/src/lib/authserver/ui/new_dir_inst.rb
+++ b/src/lib/authserver/ui/new_dir_inst.rb
@@ -140,7 +140,10 @@ class NewDirInst < UI::Dialog
       open('/etc/openldap/ldap.conf', 'w') {|fh|
         fh.puts(DS389.gen_ldap_conf(fqdn, suffix))
       }
-
+      if !DS389.enable(instance_name)
+        Popup.Error(_('Failed to enable directory instance, please inspect the journal of dirsrv@%s.service') % [instance_name])
+        raise
+      end
       UI.ReplaceWidget(Id(:busy), Empty())
       Popup.Message(_('New instance has been set up! Log output may be found in %s') % [DS_SETUP_LOG_PATH])
       finish_dialog(:next)

--- a/src/lib/authserver/ui/new_krb_inst.rb
+++ b/src/lib/authserver/ui/new_krb_inst.rb
@@ -234,6 +234,17 @@ Do you still wish to continue?'))
         raise
       end
 
+      # Kerberos may finally enable
+      if !MITKerberos.enable_kdc
+        Popup.Error(_('Failed to enable KDC, please inspect the journal of krb5kdc.service'))
+        raise
+      end
+      if !MITKerberos.enable_kadmind
+        Popup.Error(_('Failed to enable kadmind, please inspect the journal of kadmind.service'))
+        raise
+      end
+
+
       UI.ReplaceWidget(Id(:busy), Empty())
       Popup.Message(_('New instance has been set up! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
       finish_dialog(:next)


### PR DESCRIPTION
- add pkcs12 password to dialog
- fix dialog from fully qualified "domain name" to "host name"
- add info text to dialog that root dn does not append suffix per default
- make pk12util use the password to extract the certificate
- install CA certificate to system trust ring
- create ldap client configuration that commandline ldap tools work
- get server certificate nickname and create valid ldif to use the certificate
- comment out debug printout of kdb5_ldap_util command
- use directory server hostname in ldap request in kerberos setup not fqdn
- move creation of krb5.conf and kdc.conf prior trying to use kdb5_ldap_util