### PR TITLE
20190702 update kdb support for 389

### DIFF
--- a/package/yast2-auth-server.changes
+++ b/package/yast2-auth-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 1 15:24:00 UTC 2019 - William Brown <wbrown@suse.de>
+
+- Add dependency on krb5-plugin-kdb-ldap
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:26:05 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-auth-server.spec
+++ b/package/yast2-auth-server.spec
@@ -18,7 +18,7 @@
 Name:           yast2-auth-server
 Group:          System/YaST
 Summary:        A tool for creating identity management server instances
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 License:        GPL-2.0-or-later
 Url:            https://github.com/yast/yast-auth-server

--- a/src/lib/authserver/dir/client.rb
+++ b/src/lib/authserver/dir/client.rb
@@ -25,7 +25,7 @@ class LDAPClient
 
   # modify invokes ldapmodify and returns tuple of command output and boolean (success or not).
   def modify(ldif_input, ignore_existing)
-    log.info('modify: %s' % ldif_input)
+    log.info('modify: #{ldif_input}')
     stdin, stdouterr, result = Open3.popen2e('/usr/bin/ldapmodify', '-H', @url, '-x', '-D', @bind_dn, '-w', @bind_pw)
     stdin.puts(ldif_input)
     stdin.close
@@ -51,12 +51,6 @@ class LDAPClient
 objectClass: person
 objectClass: top
 sn: #{cnsn}", true)
-  end
-
-  def create_container(container_dn)
-    return self.add("dn: #{container_dn}
-objectClass: top
-objectClass: nsContainer", true)
   end
 
   # change_password changes user password for a directory object.

--- a/src/lib/authserver/krb/mit.rb
+++ b/src/lib/authserver/krb/mit.rb
@@ -16,12 +16,13 @@ require 'open3'
 # MITKerberos serves utility functions for setting up a new directory connected KDC.
 class MITKerberos
   include Yast
+  include Yast::Logger
 
   # install_pkgs installs software packages mandatory for setting up MIT Kerberos server.
   def self.install_pkgs
     Yast.import 'Package'
     # DoInstall never fails
-    Package.DoInstall(['krb5-client', 'krb5-server'].delete_if{|name| Package.Installed(name)})
+    Package.DoInstall(['krb5-client', 'krb5-server', 'krb5-plugin-kdb-ldap'].delete_if{|name| Package.Installed(name)})
   end
 
   # is_configured returns true only if there kerberos configuration has been altered.
@@ -107,7 +108,7 @@ class MITKerberos
   # init_dir uses kerberos LDAP utility to prepare a directory server for kerberos operation.
   # Returns tuple of command output and boolean (success or not).
   def self.init_dir(ldaps_addr, dir_admin_dn, dir_admin_pass, realm_name, container_dn, master_pass)
-    puts ['/usr/lib/mit/sbin/kdb5_ldap_util', '-H', 'ldaps://'+ldaps_addr, '-D', dir_admin_dn, '-w', dir_admin_pass, 'create', '-r', realm_name, '-subtrees', container_dn, '-s', '-P', master_pass].join(' ')
+    log.info( ['/usr/lib/mit/sbin/kdb5_ldap_util', '-H', 'ldaps://'+ldaps_addr, '-D', dir_admin_dn, '-w', '********', 'create', '-r', realm_name, '-subtrees', container_dn, '-s', '-P', '********'].join(' '))
     stdin, stdouterr, result = Open3.popen2e('/usr/lib/mit/sbin/kdb5_ldap_util', '-H', 'ldaps://'+ldaps_addr, '-D', dir_admin_dn, '-w', dir_admin_pass, 'create', '-r', realm_name, '-subtrees', container_dn, '-s', '-P', master_pass)
     stdin.close
     return [stdouterr.readlines.join('\n'), result.value.exitstatus == 0]

--- a/src/lib/authserver/ui/new_krb_inst.rb
+++ b/src/lib/authserver/ui/new_krb_inst.rb
@@ -54,7 +54,6 @@ class NewKrbInst < UI::Dialog
                 Frame(_('389 directory server connectivity (mandatory)'),
                       VBox(
                           InputField(Id(:dir_addr), Opt(:hstretch), _('Fully qualified domain name (e.g. dir.example.net)'), ''),
-			  InputField(Id(:dir_inst), Opt(:hstretch), _('Directory instance name (e.g. localhost)'), ''),
                           InputField(Id(:dir_suffix), Opt(:hstretch), _('Directory suffix (e.g. dc=example,dc=net)'), ''),
                           Password(Id(:dm_pass), Opt(:hstretch), _('"cn=Directory Manager" password'), ''),
                       ),
@@ -70,6 +69,7 @@ class NewKrbInst < UI::Dialog
                       InputField(Id(:admin_dn), Opt(:hstretch), _('Admin account to create (e.g. cn=krbadm)'), ''),
                       Password(Id(:admin_pass), Opt(:hstretch), _('Password of admin account'), ''),
                       Password(Id(:admin_pass_repeat), Opt(:hstretch), _('Repeat password of admin account'), ''),
+                      InputField(Id(:container_dn), Opt(:hstretch), _('KDC container DN (e.g. cn=kdc)'), ''),
                   ),
             ),
         ),
@@ -93,10 +93,9 @@ You may set one up using "New Directory Instance" program.'))
     realm = UI.QueryWidget(Id(:realm), :Value)
 
     dir_addr = UI.QueryWidget(Id(:dir_addr), :Value)
-    dir_inst = UI.QueryWidget(Id(:dir_inst), :Value)
     dir_suffix = UI.QueryWidget(Id(:dir_suffix), :Value)
-    container_dn = UI.QueryWidget(Id(:container_dn), :Value)
-    dm_dn = UI.QueryWidget(Id(:dm_dn), :Value)
+    container_dn = UI.QueryWidget(Id(:container_dn), :Value) + ',' + dir_suffix
+    dm_dn = 'cn=Directory Manager'
     dm_pass = UI.QueryWidget(Id(:dm_pass), :Value)
 
     master_pass = UI.QueryWidget(Id(:master_pass), :Value)
@@ -110,7 +109,7 @@ You may set one up using "New Directory Instance" program.'))
 
     # Validate input
     if fqdn == '' || realm == '' ||
-        dir_addr == '' || dir_inst == '' || dir_suffix == '' || container_dn == '' ||
+        dir_addr == '' || dir_suffix == '' || container_dn == '' ||
         master_pass == '' || master_pass_repeat == '' ||
         dm_dn == '' || dm_pass == '' ||
         kdc_dn_prefix == '' || kdc_pass == '' || kdc_pass_repeat == '' ||
@@ -140,102 +139,117 @@ Do you still wish to continue?'))
 
     UI.ReplaceWidget(Id(:busy), Label(_('Installing new instance, this may take a minute or two.')))
 
-    begin
-      MITKerberos.install_pkgs
-      # Enable kerberos schema on 389
-      # By default 389-ds ships with this schema enabled today.
+    MITKerberos.install_pkgs
+    # Enable kerberos schema on 389
+    # By default 389-ds ships with this schema enabled today.
 
-      # Create kerberos users and give them password in LDAP
-      kdc_dn = kdc_dn_prefix+','+dir_suffix
-      admin_dn = admin_dn_prefix+','+dir_suffix
-      ldap = LDAPClient.new('ldaps://'+fqdn, dm_dn, dm_pass)
-      out, ok = ldap.create_person(kdc_dn_prefix, 'Kerberos KDC Connection', dir_suffix)
-      MITKerberos.append_to_log(out)
-      if !ok
-        Popup.Error(_('Failed to create Kerberos KDC connection user! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
-        raise
-      end
-      out, ok = ldap.change_password(kdc_dn,kdc_pass)
-      MITKerberos.append_to_log(out)
-      if !ok
-        Popup.Error(_('Failed to create Kerberos KDC connection user! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
-        raise
-      end
-      out, ok = ldap.create_person(admin_dn_prefix, 'Kerberos Administration Connection', dir_suffix)
-      MITKerberos.append_to_log(out)
-      if !ok
-        Popup.Error(_('Failed to create Kerberos administration user! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
-        raise
-      end
-      out, ok = ldap.change_password(admin_dn,admin_pass)
-      MITKerberos.append_to_log(out)
-      if !ok
-        Popup.Error(_('Failed to create Kerberos KDC administration user! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
-        raise
-      end
-
-      # Create password file for KDC
-      pass_file_path = '/etc/dirsrv/kdc'
-      out, ok = MITKerberos.save_password_into_file(kdc_dn, kdc_pass, pass_file_path)
-      MITKerberos.append_to_log(out)
-      if !ok
-        Popup.Error(_('Failed to create password file! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
-        raise
-      end
-      out, ok = MITKerberos.save_password_into_file(admin_dn, admin_pass, pass_file_path)
-      MITKerberos.append_to_log(out)
-      if !ok
-        Popup.Error(_('Failed to create password file! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
-        raise
-      end
-
-      # Make common and KDC configuration files
-      open('/etc/krb5.conf', 'w') {|fh|
-        fh.puts(MITKerberos.gen_common_conf(realm, fqdn))
-      }
-      open('/var/lib/kerberos/krb5kdc/kdc.conf', 'w') {|fh|
-        fh.puts(MITKerberos.gen_kdc_conf(realm, kdc_dn, admin_dn, container_dn, pass_file_path, dir_addr))
-      }
-
-      # Give kerberos rights to modify directory
-      out, ok = ldap.aci_allow_modify(container_dn, 'kerberos-admin', admin_dn)
-      MITKerberos.append_to_log(out)
-      if !ok
-        Popup.Error(_('Failed to modify directory permission! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
-        raise
-      end
-      out, ok = ldap.aci_allow_modify(container_dn, 'kerberos-kdc', kdc_dn)
-      MITKerberos.append_to_log(out)
-      if !ok
-        Popup.Error(_('Failed to modify directory permission! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
-        raise
-      end
-
-      # Let kerberos do its initialisation sequence
-      out, ok = MITKerberos.init_dir(dir_addr, dm_dn, dm_pass, realm, container_dn, master_pass)
-      MITKerberos.append_to_log(out)
-      if !ok
-        Popup.Error(_('Kerberos initialisation failure! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
-        raise
-      end
-
-      # Kerberos may finally start
-      if !MITKerberos.restart_kdc
-        Popup.Error(_('Failed to start KDC, please inspect the journal of krb5kdc.service'))
-        raise
-      end
-      if !MITKerberos.restart_kadmind
-        Popup.Error(_('Failed to start kadmind, please inspect the journal of kadmind.service'))
-        raise
-      end
-
+    # Create kerberos users and give them password in LDAP
+    kdc_dn = kdc_dn_prefix+','+dir_suffix
+    MITKerberos.append_to_log(kdc_dn)
+    admin_dn = admin_dn_prefix+','+dir_suffix
+    MITKerberos.append_to_log(admin_dn)
+    ldap = LDAPClient.new('ldaps://'+dir_addr, dm_dn, dm_pass)
+    MITKerberos.append_to_log('Created ldap client')
+    out, ok = ldap.create_person(kdc_dn_prefix, 'Kerberos KDC Connection', dir_suffix)
+    MITKerberos.append_to_log('%s' % out)
+    if !ok
+      Popup.Error(_('Failed to create Kerberos KDC connection user! Log output may be found in /var/log/YaST/y2log'))
       UI.ReplaceWidget(Id(:busy), Empty())
-      Popup.Message(_('New instance has been set up! Log output may be found in %s') % [KDC_SETUP_LOG_PATH])
-      finish_dialog(:next)
-    rescue Exception => e
-      Popup.Error('There was an error ' + e.message)
-      # Give user an opportunity to correct mistake
-      UI.ReplaceWidget(Id(:busy), Empty())
+      return
     end
+    out, ok = ldap.change_password(kdc_dn,kdc_pass)
+    MITKerberos.append_to_log('%s' % out)
+    if !ok
+      Popup.Error(_('Failed to create Kerberos KDC connection user! Log output may be found in /var/log/YaST/y2log'))
+      UI.ReplaceWidget(Id(:busy), Empty())
+      return
+    end
+    out, ok = ldap.create_person(admin_dn_prefix, 'Kerberos Administration Connection', dir_suffix)
+    MITKerberos.append_to_log('%s' % out)
+    if !ok
+      Popup.Error(_('Failed to create Kerberos administration user! Log output may be found in /var/log/YaST/y2log'))
+      UI.ReplaceWidget(Id(:busy), Empty())
+      return
+    end
+    out, ok = ldap.change_password(admin_dn,admin_pass)
+    MITKerberos.append_to_log('%s' % out)
+    if !ok
+      Popup.Error(_('Failed to create Kerberos KDC administration user! Log output may be found in /var/log/YaST/y2log'))
+      UI.ReplaceWidget(Id(:busy), Empty())
+      return
+    end
+
+    # Make common and KDC configuration files
+    # This has to occur the PW files else the default realm is not known
+    # to the pwstash command below.
+    pass_file_path = '/var/lib/kerberos/krb5kdc/ldap.creds'
+
+    MITKerberos.append_to_log('Generating /etc/krb5.conf')
+    open('/etc/krb5.conf', 'w') {|fh|
+      fh.puts(MITKerberos.gen_common_conf(realm, fqdn))
+    }
+    MITKerberos.append_to_log('Generating /var/lib/kerberos/krb5kdc/kdc.conf')
+    open('/var/lib/kerberos/krb5kdc/kdc.conf', 'w') {|fh|
+      fh.puts(MITKerberos.gen_kdc_conf(realm, kdc_dn, admin_dn, container_dn, pass_file_path, dir_addr))
+    }
+
+    # Create password file for KDC
+    MITKerberos.append_to_log('Generating KRBADM/KDC Passwords to %s' % pass_file_path)
+    out, ok = MITKerberos.save_password_into_file(kdc_dn, kdc_pass, pass_file_path)
+    MITKerberos.append_to_log('%s' % out)
+    if !ok
+      Popup.Error(_('Failed to create password file! Log output may be found in /var/log/YaST/y2log'))
+      UI.ReplaceWidget(Id(:busy), Empty())
+      return
+    end
+    out, ok = MITKerberos.save_password_into_file(admin_dn, admin_pass, pass_file_path)
+    MITKerberos.append_to_log('%s' % out)
+    if !ok
+      Popup.Error(_('Failed to create password file! Log output may be found in /var/log/YaST/y2log'))
+      UI.ReplaceWidget(Id(:busy), Empty())
+      return
+    end
+
+    # Let kerberos do its initialisation sequence
+    out, ok = MITKerberos.init_dir(dir_addr, dm_dn, dm_pass, realm, container_dn, master_pass)
+    MITKerberos.append_to_log('%s' % out)
+    if !ok
+      Popup.Error(_('Kerberos initialisation failure! Log output may be found in /var/log/YaST/y2log'))
+      UI.ReplaceWidget(Id(:busy), Empty())
+      return
+    end
+
+    # Give kerberos rights to modify directory, relies on the kdc container existing
+    out, ok = ldap.aci_allow_modify(container_dn, 'kerberos-admin', admin_dn)
+    MITKerberos.append_to_log('%s' % out)
+    if !ok
+      Popup.Error(_('Failed to modify directory permission! Log output may be found in /var/log/YaST/y2log'))
+      UI.ReplaceWidget(Id(:busy), Empty())
+      return
+    end
+    out, ok = ldap.aci_allow_modify(container_dn, 'kerberos-kdc', kdc_dn)
+    MITKerberos.append_to_log('%s' % out)
+    if !ok
+      Popup.Error(_('Failed to modify directory permission! Log output may be found in /var/log/YaST/y2log'))
+      UI.ReplaceWidget(Id(:busy), Empty())
+      return
+    end
+
+    # Kerberos may finally start
+    if !MITKerberos.restart_kdc
+      Popup.Error(_('Failed to start KDC, please inspect the journal of krb5kdc.service'))
+      UI.ReplaceWidget(Id(:busy), Empty())
+      return
+    end
+    if !MITKerberos.restart_kadmind
+      Popup.Error(_('Failed to start kadmind, please inspect the journal of kadmind.service'))
+      UI.ReplaceWidget(Id(:busy), Empty())
+      return
+    end
+
+    UI.ReplaceWidget(Id(:busy), Empty())
+    Popup.Message(_('New instance has been set up! Log output may be found in /var/log/YaST/y2log'))
+    finish_dialog(:next)
+    UI.ReplaceWidget(Id(:busy), Empty())
   end
 end


### PR DESCRIPTION
This is a large rework of kdb for 389, fixing a large number of issues
that prevented the kdb setup from operating correctly. It now is able
to correctly configure and setup Kerberos against a 389 Directory
Server instance.