### PR TITLE
Added "BuildRequires: update-desktop-files"

### DIFF
--- a/package/yast2-auth-server.changes
+++ b/package/yast2-auth-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 19 09:16:56 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "BuildRequires: update-desktop-files"
+- Related to the previous desktop file changes (fate#319035)
+- 4.2.2
+
+-------------------------------------------------------------------
 Mon Jul 1 15:24:00 UTC 2019 - William Brown <wbrown@suse.de>
 
 - Add dependency on krb5-plugin-kdb-ldap

--- a/package/yast2-auth-server.spec
+++ b/package/yast2-auth-server.spec
@@ -18,7 +18,7 @@
 Name:           yast2-auth-server
 Group:          System/YaST
 Summary:        A tool for creating identity management server instances
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 License:        GPL-2.0-or-later
 Url:            https://github.com/yast/yast-auth-server
@@ -28,6 +28,7 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildRequires:  yast2
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  rubygem(yast-rake)
+BuildRequires:  update-desktop-files
 
 Requires:       net-tools
 Requires:       yast2-ruby-bindings


### PR DESCRIPTION
- The recent fix in YaST RPM macros now updates the desktop files
- The `%suse_update_desktop_file` macro is defined in the `update-desktop-files` package
- Without it the macro is not expanded and the shell treats `%` as a job control character and fails with error `fg: no job control`