### PR TITLE
Use new krb5 sbin path

### DIFF
--- a/package/yast2-auth-server.changes
+++ b/package/yast2-auth-server.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jul 13 11:39:36 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Use available kdb5_ldap_util binary (either at /usr/lib/mit/sbin
+  or /usr/sbin).
+- Related to bsc#1174078.
+- 4.2.4
+
+-------------------------------------------------------------------
 Thu Aug 22 16:16:07 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-auth-server.spec
+++ b/package/yast2-auth-server.spec
@@ -18,7 +18,7 @@
 Name:           yast2-auth-server
 Group:          System/YaST
 Summary:        A tool for creating identity management server instances
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 License:        GPL-2.0-or-later
 Url:            https://github.com/yast/yast-auth-server

--- a/test/krb_test.rb
+++ b/test/krb_test.rb
@@ -75,4 +75,108 @@ describe MITKerberos do
 '
     expect(MITKerberos.gen_kdc_conf('EXAMPLE.COM', 'cn=kdc', 'cn=adm', 'cn=container', '/pass', 'dir.example.net')).to eq(match)
   end
+
+  shared_context "kdb5_ldap_util mock" do
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/usr/lib/mit/sbin/kdb5_ldap_util").and_return(old_path)
+      allow(File).to receive(:exist?).with("/usr/sbin/kdb5_ldap_util").and_return(!old_path)
+
+      allow(File).to receive(:chmod)
+
+      allow(Open3).to receive(:popen2e).and_return([stdin, stdouterr, waiter])
+    end
+
+    let(:stdin) { instance_double(IO, puts: true, close: true) }
+
+    let(:stdouterr) { instance_double(IO, readlines: outerr) }
+
+    let(:waiter) { instance_double(Process::Waiter, value: status) }
+
+    let(:status) { instance_double(Process::Status, exitstatus: exitstatus) }
+
+    let(:outerr) { [] }
+
+    let(:exitstatus) { 0 }
+
+    let(:old_path) { false }
+  end
+
+  shared_examples "kdb5_ldap_util" do |method, *args|
+    context "when the kdb5_ldap_util is found in /usr/sbin" do
+      let(:old_path) { false }
+
+      it "calls kdb5_ldap_util from /usr/sbin" do
+        expect(Open3).to receive(:popen2e).with("/usr/sbin/kdb5_ldap_util", any_args)
+
+        MITKerberos.send(method, *args)
+      end
+    end
+
+    context "when the kdb5_ldap_util is not found in /usr/sbin" do
+      let(:old_path) { true }
+
+      it "calls kdb5_ldap_util from /usr/lib/mit/sbin" do
+        expect(Open3).to receive(:popen2e).with("/usr/lib/mit/sbin/kdb5_ldap_util", any_args)
+
+        MITKerberos.send(method, *args)
+      end
+    end
+
+    context "on success" do
+      let(:outerr) { ["message1", "error1"] }
+
+      let(:exitstatus) { 0 }
+
+      it "returns stdouterr and true" do
+        result = MITKerberos.send(method, *args)
+
+        expect(result).to eq(["message1\\nerror1", true])
+      end
+    end
+
+    context "on failure" do
+      let(:outerr) { ["message1", "error1"] }
+
+      let(:exitstatus) { 1 }
+
+      it "returns stdouterr and false" do
+        result = MITKerberos.send(method, *args)
+
+        expect(result).to eq(["message1\\nerror1", false])
+      end
+    end
+  end
+
+  describe ".save_password_into_file" do
+    include_context "kdb5_ldap_util mock"
+
+    it "calls kdb5_ldap_util with correct arguments" do
+      expect(Open3).to receive(:popen2e)
+        .with(/kdb5_ldap_util/, "stashsrvpw", "-f", "path/to/file", "-w", "pass", "example")
+
+      MITKerberos.save_password_into_file("example", "pass", "path/to/file")
+    end
+
+    include_examples "kdb5_ldap_util", :save_password_into_file, "example", "pass", "path/to/file"
+  end
+
+  describe ".init_dir" do
+    include_context "kdb5_ldap_util mock"
+
+    it "calls kdb5_ldap_util with correct arguments" do
+      expect(Open3).to receive(:popen2e)
+        .with(/kdb5_ldap_util/,
+          "-H", "ldaps://addr",
+          "-D", "dn",
+          "-w", "a_pass",
+          "create", "-r", "name",
+          "-subtrees", "c_dn",
+          "-s", "-P", "m_pass")
+
+      MITKerberos.init_dir("addr", "dn", "a_pass", "name", "c_dn", "m_pass")
+    end
+
+    include_examples "kdb5_ldap_util", :init_dir, "addr", "dn", "a_pass", "name", "c_dn", "m_pass"
+  end
 end


### PR DESCRIPTION
## Problem

The package *krb5* was adapted to provide binaries at */usr/sbin* path instead of */usr/lib/mit/sbin*, see https://build.opensuse.org/request/show/814662.

YaST is still using the old */usr/lib/mit/sbin* paths. 

* https://trello.com/c/PxH6LJhf/1951-3-new-krb5-path-in-tw

* https://bugzilla.opensuse.org/show_bug.cgi?id=1174078

## Solution

Adapt YaST code to use the new paths.

Note: the changes in the *kbr5* package were done without a change in the version number, so *yast2-server-auth* cannot indicate a conflict with any *kbr5* old version. And also note that this new *yast2-auth-server* package will be submitted to both: SLE-15-SP3 and Factory, but most likely SLE-15-SP3 will not receive any update for *kbr5*. Because that, *yast2-auth-server* has to deal with both possible paths (/usr/lib/mit/sbin and /usr/sbin).

## Testing

* Added unit tests.
