### PR TITLE
Fix y2log path in popup messages

### DIFF
--- a/package/yast2-auth-server.changes
+++ b/package/yast2-auth-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb  6 10:58:59 UTC 2023 - Samuel Cabrero <scabrero@suse.de>
+
+- Fix y2log path in popup messages (bsc#1207831)
+- 4.3.0
+
+-------------------------------------------------------------------
 Mon Jul 13 11:39:36 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Use available kdb5_ldap_util binary (either at /usr/lib/mit/sbin

--- a/package/yast2-auth-server.spec
+++ b/package/yast2-auth-server.spec
@@ -18,7 +18,7 @@
 Name:           yast2-auth-server
 Group:          System/YaST
 Summary:        A tool for creating identity management server instances
-Version:        4.2.4
+Version:        4.3.0
 Release:        0
 License:        GPL-2.0-or-later
 Url:            https://github.com/yast/yast-auth-server

--- a/src/lib/authserver/dir/ds389.rb
+++ b/src/lib/authserver/dir/ds389.rb
@@ -56,7 +56,7 @@ suffix = #{suffix}
   end
 
   # exec_setup runs setup-ds.pl using input parameters file content.
-  # The output of setup script is written into file .y2log or /var/log/YaST/y2log
+  # The output of setup script is written into file .y2log or /var/log/YaST2/y2log
   # Returns true only if setup was successful.
   def self.exec_setup(content)
     append_to_log('Beginning YAST auth server installation ...')

--- a/src/lib/authserver/ui/new_dir_inst.rb
+++ b/src/lib/authserver/ui/new_dir_inst.rb
@@ -120,7 +120,13 @@ class NewDirInst < UI::Dialog
     # Always remove the ini file
     DS389.remove_setup_ini
     if !ok
-      Popup.Error(_('Failed to set up new instance! Log output may be found in /var/log/YaST/y2log'))
+      Popup.Error(
+        # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+        format(
+          _('Failed to set up new instance! Log output may be found in %{y2log_path}/y2log'),
+          y2log_path: Yast::Directory.logdir
+        )
+      )
       UI.ReplaceWidget(Id(:busy), Empty())
       return
     end
@@ -129,7 +135,13 @@ class NewDirInst < UI::Dialog
       UI.ReplaceWidget(Id(:busy), Label(_('Configuring instance TLS ...')))
       # Turn on TLS
       if !DS389.install_tls_in_nss(instance_name, tls_ca, tls_p12)
-        Popup.Error(_('Failed to set up new instance! Log output may be found in /var/log/YaST/y2log'))
+        Popup.Error(
+          # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+          format(
+            _('Failed to set up new instance! Log output may be found in %{y2log_path}/y2log'),
+            y2log_path: Yast::Directory.logdir
+          )
+        )
         UI.ReplaceWidget(Id(:busy), Empty())
         return
       end
@@ -142,7 +154,13 @@ class NewDirInst < UI::Dialog
     end
 
     UI.ReplaceWidget(Id(:busy), Empty())
-    Popup.Message(_('New instance has been set up! Log output may be found in /var/log/YaST/y2log'))
+    Popup.Message(
+      # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+      format(
+        _('New instance has been set up! Log output may be found in %{y2log_path}/y2log'),
+        y2log_path: Yast::Directory.logdir
+      )
+    )
     finish_dialog(:next)
     UI.ReplaceWidget(Id(:busy), Empty())
   end

--- a/src/lib/authserver/ui/new_krb_inst.rb
+++ b/src/lib/authserver/ui/new_krb_inst.rb
@@ -153,28 +153,52 @@ Do you still wish to continue?'))
     out, ok = ldap.create_person(kdc_dn_prefix, 'Kerberos KDC Connection', dir_suffix)
     MITKerberos.append_to_log('%s' % out)
     if !ok
-      Popup.Error(_('Failed to create Kerberos KDC connection user! Log output may be found in /var/log/YaST/y2log'))
+      Popup.Error(
+        # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+        format(
+          _('Failed to create Kerberos KDC connection user! Log output may be found in %{y2log_path}/y2log'),
+          y2log_path: Yast::Directory.logdir
+        )
+      )
       UI.ReplaceWidget(Id(:busy), Empty())
       return
     end
     out, ok = ldap.change_password(kdc_dn,kdc_pass)
     MITKerberos.append_to_log('%s' % out)
     if !ok
-      Popup.Error(_('Failed to create Kerberos KDC connection user! Log output may be found in /var/log/YaST/y2log'))
+      Popup.Error(
+        # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+        format(
+          _('Failed to create Kerberos KDC connection user! Log output may be found in %{y2log_path}/y2log'),
+          y2log_path: Yast::Directory.logdir
+        )
+      )
       UI.ReplaceWidget(Id(:busy), Empty())
       return
     end
     out, ok = ldap.create_person(admin_dn_prefix, 'Kerberos Administration Connection', dir_suffix)
     MITKerberos.append_to_log('%s' % out)
     if !ok
-      Popup.Error(_('Failed to create Kerberos administration user! Log output may be found in /var/log/YaST/y2log'))
+      Popup.Error(
+        # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+        format(
+          _('Failed to create Kerberos administration user! Log output may be found in %{y2log_path}/y2log'),
+          y2log_path: Yast::Directory.logdir
+        )
+      )
       UI.ReplaceWidget(Id(:busy), Empty())
       return
     end
     out, ok = ldap.change_password(admin_dn,admin_pass)
     MITKerberos.append_to_log('%s' % out)
     if !ok
-      Popup.Error(_('Failed to create Kerberos KDC administration user! Log output may be found in /var/log/YaST/y2log'))
+      Popup.Error(
+        # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+        format(
+          _('Failed to create Kerberos KDC administration user! Log output may be found in %{y2log_path}/y2log'),
+          y2log_path: Yast::Directory.logdir
+        )
+      )
       UI.ReplaceWidget(Id(:busy), Empty())
       return
     end
@@ -198,14 +222,26 @@ Do you still wish to continue?'))
     out, ok = MITKerberos.save_password_into_file(kdc_dn, kdc_pass, pass_file_path)
     MITKerberos.append_to_log('%s' % out)
     if !ok
-      Popup.Error(_('Failed to create password file! Log output may be found in /var/log/YaST/y2log'))
+      Popup.Error(
+        # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+        format(
+          _('Failed to create password file! Log output may be found in %{y2log_path}/y2log'),
+          y2log_path: Yast::Directory.logdir
+        )
+      )
       UI.ReplaceWidget(Id(:busy), Empty())
       return
     end
     out, ok = MITKerberos.save_password_into_file(admin_dn, admin_pass, pass_file_path)
     MITKerberos.append_to_log('%s' % out)
     if !ok
-      Popup.Error(_('Failed to create password file! Log output may be found in /var/log/YaST/y2log'))
+      Popup.Error(
+        # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+        format(
+          _('Failed to create password file! Log output may be found in %{y2log_path}/y2log'),
+          y2log_path: Yast::Directory.logdir
+        )
+      )
       UI.ReplaceWidget(Id(:busy), Empty())
       return
     end
@@ -214,7 +250,13 @@ Do you still wish to continue?'))
     out, ok = MITKerberos.init_dir(dir_addr, dm_dn, dm_pass, realm, container_dn, master_pass)
     MITKerberos.append_to_log('%s' % out)
     if !ok
-      Popup.Error(_('Kerberos initialisation failure! Log output may be found in /var/log/YaST/y2log'))
+      Popup.Error(
+        # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+        format(
+          _('Kerberos initialisation failure! Log output may be found in %{y2log_path}/y2log'),
+          y2log_path: Yast::Directory.logdir
+        )
+      )
       UI.ReplaceWidget(Id(:busy), Empty())
       return
     end
@@ -223,14 +265,26 @@ Do you still wish to continue?'))
     out, ok = ldap.aci_allow_modify(container_dn, 'kerberos-admin', admin_dn)
     MITKerberos.append_to_log('%s' % out)
     if !ok
-      Popup.Error(_('Failed to modify directory permission! Log output may be found in /var/log/YaST/y2log'))
+      Popup.Error(
+        # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+        format(
+          _('Failed to modify directory permission! Log output may be found in %{y2log_path}/y2log'),
+          y2log_path: Yast::Directory.logdir
+        )
+      )
       UI.ReplaceWidget(Id(:busy), Empty())
       return
     end
     out, ok = ldap.aci_allow_modify(container_dn, 'kerberos-kdc', kdc_dn)
     MITKerberos.append_to_log('%s' % out)
     if !ok
-      Popup.Error(_('Failed to modify directory permission! Log output may be found in /var/log/YaST/y2log'))
+      Popup.Error(
+        # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+        format(
+          _('Failed to modify directory permission! Log output may be found in %{y2log_path}/y2log'),
+          y2log_path: Yast::Directory.logdir
+        )
+      )
       UI.ReplaceWidget(Id(:busy), Empty())
       return
     end
@@ -248,7 +302,13 @@ Do you still wish to continue?'))
     end
 
     UI.ReplaceWidget(Id(:busy), Empty())
-    Popup.Message(_('New instance has been set up! Log output may be found in /var/log/YaST/y2log'))
+    Popup.Message(
+      # TRANSLATORS: %{y2log_path} is replaced by the YaST2 logs path.
+      format(
+        _('New instance has been set up! Log output may be found in %{y2log_path}/y2log'),
+        y2log_path: Yast::Directory.logdir
+      )
+    )
     finish_dialog(:next)
     UI.ReplaceWidget(Id(:busy), Empty())
   end


### PR DESCRIPTION
## Problem

The popup messages refer to /var/log/YaST/y2log when it should be /var/log/YaST2/y2log.

- https://bugzilla.suse.com/show_bug.cgi?id=1207831
