### PR TITLE
Stop using File.exists? which no longer works in Ruby 3.2 (bsc#1206419)

### DIFF
--- a/package/yast2-auth-server.changes
+++ b/package/yast2-auth-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar  6 17:06:25 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Stop using File.exists? which no longer works in Ruby 3.2
+  (bsc#1206419)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-auth-server.spec
+++ b/package/yast2-auth-server.spec
@@ -18,7 +18,7 @@
 Name:           yast2-auth-server
 Group:          System/YaST
 Summary:        A tool for creating identity management server instances
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 License:        GPL-2.0-or-later
 Url:            https://github.com/yast/yast-auth-server

--- a/src/lib/authserver/ui/new_dir_inst.rb
+++ b/src/lib/authserver/ui/new_dir_inst.rb
@@ -102,7 +102,7 @@ class NewDirInst < UI::Dialog
       Popup.Error(_('Both TLS Certificate authority and PKCS12 must be provided, or none provided.'))
       return
     end
-    if (tls_ca != '' && tls_p12 != '') && (!File.exists?(tls_ca) || !File.exists?(tls_p12))
+    if (tls_ca != '' && tls_p12 != '') && (!File.exist?(tls_ca) || !File.exist?(tls_p12))
       Popup.Error(_('TLS certificate authority PEM OR certificate/key PKCS12 file does not exist.'))
       return
     end


### PR DESCRIPTION
## Problem

Ruby 3.2 removed `File.exists?` which has been long deprecated in favor of `File.exist?`

Here it would crash after pressing `OK` in the "Create New Directory Instance" dialog.

- https://trello.com/c/jRe5bWVE
- https://bugzilla.suse.com/show_bug.cgi?id=1206419
 
## Solution

Use correct method name

## Testing

TODO

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*
