### PR TITLE
Add missing reference in the changes file

### DIFF
--- a/package/yast2-auth-server.changes
+++ b/package/yast2-auth-server.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Apr 24 21:29:00 UTC 2023 - William Brown <william.brown@suse.com>
 
-- Add deprecation notice to this tool
+- Add deprecation notice to this tool (bsc#1211734).
 - 4.6.2
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A deprecation warning was added in https://github.com/yast/yast-auth-server/pull/80 but the version bump and changes file update done in https://github.com/yast/yast-auth-server/pull/82 without a Bugzilla/Jira/Github entry for pleasing OBS bots. Thus, our Jenkins job [rejected to send changes](https://github.com/yast/yast-auth-server/pull/82#issuecomment-1520187256).


## Solution

To use the [Bugzilla reference explicitly created](https://github.com/yast/yast-auth-server/pull/82#issuecomment-1563684280) for addressing this _issue_.


## Testing

N/A


## Screenshots

N/A

